### PR TITLE
Small correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 
         <p>
             This request specifies that we want to get or create a node uniquely based on the
-            <code>name</code> property having the value <code>1000</code>. We can then specify
+            <code>id</code> property having the value <code>1000</code>. We can then specify
             the properties we want to store on the node if it is created.
         </p>
         


### PR DESCRIPTION
Specifying that the property looked up against for the first case of unique creation is `id` instead of `name`.
